### PR TITLE
chain: encapsulate exceptions in rejections

### DIFF
--- a/lib/pacta.js
+++ b/lib/pacta.js
@@ -284,13 +284,17 @@
             mapped = this.map(f);
 
         mapped.map(function (pb) {
-            pb.map(function (value) {
-                promise.resolve(value);
-            });
+            try {
+                pb.map(function (value) {
+                    promise.resolve(value);
+                });
 
-            pb.onRejected(function (reason) {
-                promise.reject(reason);
-            });
+                pb.onRejected(function (reason) {
+                    promise.reject(reason);
+                });
+            } catch (e) {
+                promise.reject(e);
+            }
         });
 
         mapped.onRejected(function (reason) {
@@ -304,15 +308,20 @@
     Promise.prototype.chainError = function (f) {
         var promise = new Promise();
 
-        /* Same algorithm as above */
-        this.mapError(f).mapError(function (pb) {
-            pb.map(function (value) {
-                promise.resolve(value);
-            });
+        this.mapError(function (reason) {
+            try {
+                var pb = f(reason);
 
-            pb.onRejected(function (reason) {
-                promise.reject(reason);
-            });
+                pb.map(function (value) {
+                    promise.resolve(value);
+                });
+
+                pb.onRejected(function (reason) {
+                    promise.reject(reason);
+                });
+            } catch (e) {
+                promise.reject(e);
+            }
         });
 
         this.map(function(value) {

--- a/lib/pacta.js
+++ b/lib/pacta.js
@@ -282,7 +282,8 @@
          * resolve another promise with it. Return that promise as it is equivalent
          * to Promise b.
          */
-        this.map(f).map(function (pb) {
+        var mapped = this.map(f);
+        mapped.map(function (pb) {
             pb.map(function (value) {
                 promise.resolve(value);
             });
@@ -292,7 +293,7 @@
             });
         });
 
-        this.onRejected(function (reason) {
+        mapped.onRejected(function (reason) {
             promise.reject(reason);
         });
 

--- a/lib/pacta.js
+++ b/lib/pacta.js
@@ -274,15 +274,15 @@
 
     /* chain :: Promise e a -> (a -> Promise e b) -> Promise e b */
     Promise.prototype.chain = function (f) {
-        var promise = new Promise();
-
         /* Map over the given Promise a with (a -> Promise b), returning a new
          * Promise (Promise b). Map over that, thereby gaining access to the inner
          * Promise b. Map over that in order to get to the inner value of b and
          * resolve another promise with it. Return that promise as it is equivalent
          * to Promise b.
          */
-        var mapped = this.map(f);
+        var promise = new Promise(),
+            mapped = this.map(f);
+
         mapped.map(function (pb) {
             pb.map(function (value) {
                 promise.resolve(value);

--- a/test/pacta_test.js
+++ b/test/pacta_test.js
@@ -11,6 +11,12 @@
     'use strict';
 
     describe('Promise', function () {
+        function rejected(reason) {
+            var p = new Promise();
+            p.reject(reason);
+            return p;
+        }
+
         var p, p2, p3, p4, p5, p6, p7;
 
         beforeEach(function () {
@@ -549,6 +555,16 @@
                     done();
                 });
             });
+
+            it('rejects the returned promise, if f does not return a promise', function (done) {
+                var p = Promise.of().chain(function () { return 'not-a-promise'; });
+
+                p.onRejected(function (r) {
+                    assert.equal('rejected', p.state());
+                    assert.equal(TypeError, r.constructor);
+                    done();
+                });
+            });
         });
 
         describe('#chainError', function () {
@@ -568,6 +584,28 @@
 
                 p5.chainError(function (x) { return f(x).chainError(g); }).mapError(function (x) {
                     assert.equal('g(f(foo))', x);
+                    done();
+                });
+            });
+
+            it('encapsulates exceptions in rejections', function (done) {
+                var exception = new TypeError();
+
+                var p = rejected().chainError(function () { throw  exception; });
+
+                p.onRejected(function (r) {
+                    assert.equal('rejected', p.state());
+                    assert.equal(exception, r);
+                    done();
+                });
+            });
+
+            it('rejects the returned promise, if f does not return a promise', function (done) {
+                var p = rejected().chainError(function () { return 'not-a-promise'; });
+
+                p.onRejected(function (r) {
+                    assert.equal('rejected', p.state());
+                    assert.equal(TypeError, r.constructor);
                     done();
                 });
             });

--- a/test/pacta_test.js
+++ b/test/pacta_test.js
@@ -537,6 +537,18 @@
                     done();
                 });
             });
+
+            it('encapsulates exceptions in rejections', function (done) {
+                var exception = new TypeError();
+
+                var p = Promise.of().chain(function () { throw exception; });
+
+                p.onRejected(function (r) {
+                    assert.equal('rejected', p.state());
+                    assert.equal(exception, r);
+                    done();
+                });
+            });
         });
 
         describe('#chainError', function () {


### PR DESCRIPTION
`#chain` was dropping exceptions thrown by the use provided function `f`. I added a test case and changed the behavior so that the returned promise is rejected.

I did not (have to) change `#chainError` because it's not affected by this issue. However, it is affected by a related one. If its function `f` throws, the first `#mapError` will not return a promise of a promise of an error, but a promise of an error. This type error will also be silently dropped. If you want I can create a separate pull request to fix that as well.