### PR TITLE
Deterministic tests with builder methods

### DIFF
--- a/test/pacta_test.js
+++ b/test/pacta_test.js
@@ -11,15 +11,33 @@
     'use strict';
 
     describe('Promise', function () {
-        function rejected(reason) {
+        function emptyPromise() {
+            return new Promise();
+        }
+
+        function rejectedPromise(reason) {
             var p = new Promise();
+
+            if (reason === undefined) {
+                reason = 'error';
+            }
+
             p.reject(reason);
+
             return p;
+        }
+
+        function fulfilledPromise(value) {
+            if (value === undefined) {
+                value = 1;
+            }
+
+            return Promise.of(value);
         }
 
         describe('.of', function () {
             it('wraps a value in a new promise', function (done) {
-                Promise.of(1).map(function (x) {
+                fulfilledPromise(1).map(function (x) {
                     assert.equal(1, x);
                     done();
                 });
@@ -28,37 +46,30 @@
 
         describe('#state', function () {
             it('is pending for unfulfilled and unrejected promises', function () {
-                var p = new Promise();
-
-                assert.equal('pending', p.state());
+                assert.equal('pending', emptyPromise().state());
             });
 
             it('is fulfilled for fulfilled promises', function () {
-                var p = Promise.of(1);
-
-                assert.equal('fulfilled', p.state());
+                assert.equal('fulfilled', fulfilledPromise().state());
             });
 
             it('is rejected for rejected promises', function () {
-                var p = new Promise();
-                p.reject('error');
-
-                assert.equal('rejected', p.state());
+                assert.equal('rejected', rejectedPromise().state());
             });
         });
 
         describe('#resolve', function () {
             it('resolves a promise with its final value', function () {
-                var p = new Promise();
+                var p = emptyPromise();
                 p.resolve(1);
 
                 assert.equal('fulfilled', p.state());
             });
 
             it('triggers any listeners for resolution', function (done) {
-                var triggered = false;
+                var triggered = false,
+                    p = emptyPromise();
 
-                var p = new Promise();
                 p.map(function () {
                     triggered = true;
                 });
@@ -73,17 +84,16 @@
             });
 
             it('does nothing to rejected promises', function () {
-                var p = new Promise();
-                p.reject('error');
+                var p = rejectedPromise();
                 p.resolve(1);
 
                 assert.equal('rejected', p.state());
             });
 
             it('does not trigger listeners if the promise is rejected', function () {
-                var triggered = false;
+                var triggered = false,
+                    p = rejectedPromise();
 
-                var p = new Promise();
                 p.reject('error');
                 p.map(function () {
                     triggered = true;
@@ -96,23 +106,23 @@
 
         describe('#reject', function () {
             it('rejects a promise, setting a reason', function () {
-                var p = new Promise();
+                var p = emptyPromise();
                 p.reject('error');
 
                 assert.equal('rejected', p.state());
             });
 
             it('does nothing to fulfilled promises', function () {
-                var p = Promise.of(1);
+                var p = fulfilledPromise();
                 p.reject('error');
 
                 assert.equal('fulfilled', p.state());
             });
 
             it('triggers onRejected listeners', function (done) {
-                var triggered = false;
+                var triggered = false,
+                    p = emptyPromise();
 
-                var p = new Promise();
                 p.onRejected(function () {
                     triggered = true;
                 });
@@ -126,9 +136,9 @@
             });
 
             it('does not trigger onRejected listeners if already fulfilled', function () {
-                var triggered = false;
+                var triggered = false,
+                    p = fulfilledPromise();
 
-                var p = Promise.of(1);
                 p.onRejected(function () {
                     triggered = true;
                 });
@@ -140,8 +150,7 @@
 
         describe('#onRejected', function () {
             it('binds a listener to be fired on rejection', function (done) {
-                var p = new Promise();
-                p.reject('error');
+                var p = rejectedPromise('error');
 
                 p.onRejected(function (reason) {
                     assert.equal('error', reason);
@@ -150,13 +159,11 @@
             });
 
             it('can be used to recover from a rejection', function (done) {
-                var p = new Promise();
-                p.reject(new TypeError());
-
-                var p2 = p.onRejected(function () {
-                    assert.equal('rejected', p.state());
-                    return 'Some safe default';
-                });
+                var p1 = rejectedPromise(new TypeError()),
+                    p2 = p1.onRejected(function () {
+                        assert.equal('rejected', p1.state());
+                        return 'Some safe default';
+                    });
 
                 p2.map(function (x) {
                     assert.equal('fulfilled', p2.state());
@@ -166,13 +173,11 @@
             });
 
             it('can chain failures', function (done) {
-                var p = new Promise();
-                p.reject(new TypeError());
-
-                var p2 = p.onRejected(function () {
-                    assert.equal('rejected', p.state());
-                    throw new TypeError();
-                });
+                var p1 = rejectedPromise(new TypeError()),
+                    p2 = p1.onRejected(function () {
+                        assert.equal('rejected', p1.state());
+                        throw new TypeError();
+                    });
 
                 p2.onRejected(function () {
                     assert.equal('rejected', p2.state());
@@ -183,16 +188,14 @@
 
         describe('#map', function () {
             it('yields the value of the promise', function (done) {
-                var p = Promise.of('foo');
-
-                p.map(function (x) {
+                fulfilledPromise('foo').map(function (x) {
                     assert.equal('foo', x);
                     done();
                 });
             });
 
             it('yields the value after resolution', function (done) {
-                var p = new Promise();
+                var p = emptyPromise();
                 setTimeout(function () { p.resolve('foo'); }, 50);
 
                 p.map(function () {
@@ -205,7 +208,7 @@
             });
 
             it('can be chained', function (done) {
-                var p = Promise.of('foo');
+                var p = fulfilledPromise('foo');
 
                 p.map(function (x) {
                     return x + '!';
@@ -216,11 +219,11 @@
             });
 
             it('can be nested', function (done) {
-                var p = Promise.of('foo'),
-                    p2 = Promise.of('bar'),
-                    p3 = Promise.of('baz');
+                var p1 = fulfilledPromise('foo'),
+                    p2 = fulfilledPromise('bar'),
+                    p3 = fulfilledPromise('baz');
 
-                p.map(function (x) {
+                p1.map(function (x) {
                     p2.map(function (y) {
                         p3.map(function (z) {
                             assert.equal('foo', x);
@@ -234,7 +237,7 @@
 
             it('encapsulates exceptions in rejections', function (done) {
                 var exception = new TypeError(),
-                    p = Promise.of('foo').map(function () {
+                    p = fulfilledPromise('foo').map(function () {
                         throw exception;
                     });
 
@@ -246,7 +249,7 @@
             });
 
             it('fulfils the identity property of a functor', function (done) {
-                Promise.of('foo').map(function (x) {
+                fulfilledPromise('foo').map(function (x) {
                     return x;
                 }).map(function (x) {
                     assert.equal('foo', x);
@@ -258,7 +261,7 @@
                 var f = function (x) { return 'f(' + x + ')'; },
                     g = function (x) { return 'g(' + x + ')'; };
 
-                Promise.of('foo').map(function (x) { return f(g(x)); }).map(function (x) {
+                fulfilledPromise('foo').map(function (x) { return f(g(x)); }).map(function (x) {
                     assert.equal('f(g(foo))', x);
                     done();
                 });
@@ -268,7 +271,7 @@
                 var f = function (x) { return 'f(' + x + ')'; },
                     g = function (x) { return 'g(' + x + ')'; };
 
-                Promise.of('foo').map(g).map(f).map(function (x) {
+                fulfilledPromise('foo').map(g).map(f).map(function (x) {
                     assert.equal('f(g(foo))', x);
                     done();
                 });
@@ -277,14 +280,14 @@
 
         describe('#mapError', function () {
             it('yields the reason of the promise', function (done) {
-                rejected('foo').mapError(function (x) {
+                rejectedPromise('foo').mapError(function (x) {
                     assert.equal('foo', x);
                     done();
                 });
             });
 
             it('yields the reason after rejection', function (done) {
-                var p = new Promise();
+                var p = emptyPromise();
                 setTimeout(function () { p.reject('foo'); }, 50);
 
                 p.mapError(function () {
@@ -297,9 +300,7 @@
             });
 
             it('can be chained', function (done) {
-                var p = rejected('foo');
-
-                p.mapError(function (x) {
+                rejectedPromise('foo').mapError(function (x) {
                     return x + '!';
                 }).mapError(function (y) {
                     assert.equal('foo!', y);
@@ -308,11 +309,11 @@
             });
 
             it('can be nested', function (done) {
-                var p = rejected('foo'),
-                    p2 = rejected('bar'),
-                    p3 = rejected('baz');
+                var p1 = rejectedPromise('foo'),
+                    p2 = rejectedPromise('bar'),
+                    p3 = rejectedPromise('baz');
 
-                p.mapError(function (x) {
+                p1.mapError(function (x) {
                     p2.mapError(function (y) {
                         p3.mapError(function (z) {
                             assert.equal('foo', x);
@@ -326,24 +327,24 @@
 
             it('encapsulates exceptions in rejections', function (done) {
                 var exception = new TypeError(),
-                    pe1 = new Promise(),
-                    pe2;
+                    p1 = emptyPromise(),
+                    p2;
 
-                pe1.reject('foo');
+                p1.reject('foo');
 
-                pe2 = pe1.mapError(function () {
+                p2 = p1.mapError(function () {
                     throw exception;
                 });
 
-                pe2.onRejected(function (r) {
-                    assert.equal('rejected', pe2.state());
+                p2.onRejected(function (r) {
+                    assert.equal('rejected', p2.state());
                     assert.equal(exception, r);
                     done();
                 });
             });
 
             it('fulfils the identity property of a functor', function (done) {
-                rejected('foo').mapError(function (x) {
+                rejectedPromise('foo').mapError(function (x) {
                     return x;
                 }).mapError(function (x) {
                     assert.equal('foo', x);
@@ -355,7 +356,7 @@
                 var f = function (x) { return 'f(' + x + ')'; },
                     g = function (x) { return 'g(' + x + ')'; };
 
-                rejected('foo').mapError(function (x) { return f(g(x)); }).mapError(function (x) {
+                rejectedPromise('foo').mapError(function (x) { return f(g(x)); }).mapError(function (x) {
                     assert.equal('f(g(foo))', x);
                     done();
                 });
@@ -365,7 +366,7 @@
                 var f = function (x) { return 'f(' + x + ')'; },
                     g = function (x) { return 'g(' + x + ')'; };
 
-                rejected('foo').mapError(g).mapError(f).mapError(function (x) {
+                rejectedPromise('foo').mapError(g).mapError(f).mapError(function (x) {
                     assert.equal('f(g(foo))', x);
                     done();
                 });
@@ -374,14 +375,14 @@
 
         describe('#then', function () {
             it('yields its value like #map', function (done) {
-                Promise.of('foo').then(function (x) {
+                fulfilledPromise('foo').then(function (x) {
                     assert.equal('foo', x);
                     done();
                 });
             });
 
             it('can be chained when returning a value', function (done) {
-                Promise.of('foo').then(function (x) {
+                fulfilledPromise('foo').then(function (x) {
                     return x + '!';
                 }).then(function (x) {
                     assert.equal('foo!', x);
@@ -390,8 +391,8 @@
             });
 
             it('does not wrap a promise in a promise', function (done) {
-                Promise.of('foo').then(function (x) {
-                    return Promise.of(x);
+                fulfilledPromise('foo').then(function (x) {
+                    return fulfilledPromise(x);
                 }).map(function (x) {
                     assert.equal('foo', x);
                     done();
@@ -399,18 +400,16 @@
             });
 
             it('always returns a promise', function () {
-                assert.equal(Promise, Promise.of('foo').then().constructor);
+                assert.equal(Promise, fulfilledPromise('foo').then().constructor);
             });
 
             it('returns a fulfilled promise with the return value of onRejected', function (done) {
-                var p = new Promise();
-                p.reject('foo');
-
-                var p2 = p.then(function () {
-                    return 1;
-                }, function () {
-                    return 'error';
-                });
+                var p1 = rejectedPromise('foo'),
+                    p2 = p1.then(function () {
+                        return 1;
+                    }, function () {
+                        return 'error';
+                    });
 
                 p2.map(function (x) {
                     assert.equal('error', x);
@@ -420,12 +419,12 @@
             });
 
             it('assumes the return value of onFulfilled', function (done) {
-                var p = Promise.of('foo');
-                var p2 = p.then(function () {
-                    return 1;
-                }, function () {
-                    return 'error';
-                });
+                var p1 = fulfilledPromise('foo'),
+                    p2 = p1.then(function () {
+                        return 1;
+                    }, function () {
+                        return 'error';
+                    });
 
                 p2.map(function (x) {
                     assert.equal(1, x);
@@ -437,11 +436,11 @@
 
         describe('#concat', function () {
             it('fulfils the associativity property of semigroups #1', function (done) {
-                var p = Promise.of([1]);
-                var p2 = Promise.of([2]);
-                var p3 = Promise.of([3]);
+                var p1 = fulfilledPromise([1]),
+                    p2 = fulfilledPromise([2]),
+                    p3 = fulfilledPromise([3]);
 
-                p.concat(p2).concat(p3).map(function (x) {
+                p1.concat(p2).concat(p3).map(function (x) {
                     assert.equal(1, x[0]);
                     assert.equal(2, x[1]);
                     assert.equal(3, x[2]);
@@ -450,11 +449,11 @@
             });
 
             it('fulfils the associativity property of semigroups #2', function (done) {
-                var p = Promise.of([1]);
-                var p2 = Promise.of([2]);
-                var p3 = Promise.of([3]);
+                var p1 = fulfilledPromise([1]),
+                    p2 = fulfilledPromise([2]),
+                    p3 = fulfilledPromise([3]);
 
-                p.concat(p2.concat(p3)).map(function (x) {
+                p1.concat(p2.concat(p3)).map(function (x) {
                     assert.equal(1, x[0]);
                     assert.equal(2, x[1]);
                     assert.equal(3, x[2]);
@@ -463,11 +462,11 @@
             });
 
             it('fulfils the identity of a semigroup', function (done) {
-                var p = Promise.of([1]);
-                var p2 = Promise.of([2]);
-                var p3 = Promise.of([3]);
+                var p1 = fulfilledPromise([1]),
+                    p2 = fulfilledPromise([2]),
+                    p3 = fulfilledPromise([3]);
 
-                p.concat(p2).concat(p3).map(function (x) {
+                p1.concat(p2).concat(p3).map(function (x) {
                     return x;
                 }).map(function (x) {
                     assert.deepEqual([1, 2, 3], x);
@@ -476,37 +475,41 @@
             });
 
             it('concatenates any monoid including strings', function (done) {
-                Promise.of('foo').concat(Promise.of('bar')).concat(Promise.of('baz')).map(function (x) {
+                var p1 = fulfilledPromise('foo'),
+                    p2 = fulfilledPromise('bar'),
+                    p3 = fulfilledPromise('baz');
+
+                p1.concat(p2).concat(p3).map(function (x) {
                     assert.equal('foobarbaz', x);
                     done();
                 });
             });
 
             it('is rejected if the first promise is rejected', function (done) {
-                var p = rejected('Foo'),
-                    p2 = Promise.of('bar');
+                var p1 = rejectedPromise('Foo'),
+                    p2 = fulfilledPromise('bar');
 
-                p.concat(p2).onRejected(function (reason) {
+                p1.concat(p2).onRejected(function (reason) {
                     assert.equal('Foo', reason);
                     done();
                 });
             });
 
             it('is rejected if the second promise is rejected', function (done) {
-                var p = Promise.of('foo'),
-                    p2 = rejected('Foo');
+                var p1 = fulfilledPromise('foo'),
+                    p2 = rejectedPromise('Foo');
 
-                p.concat(p2).onRejected(function (reason) {
+                p1.concat(p2).onRejected(function (reason) {
                     assert.equal('Foo', reason);
                     done();
                 });
             });
 
             it('takes the first rejection if both promises are rejected', function (done) {
-                var p = rejected('Foo'),
-                    p2 = rejected('Bar');
+                var p1 = rejectedPromise('Foo'),
+                    p2 = rejectedPromise('Bar');
 
-                p.concat(p2).onRejected(function (reason) {
+                p1.concat(p2).onRejected(function (reason) {
                     assert.equal('Foo', reason);
                     done();
                 });
@@ -515,20 +518,20 @@
 
         describe('#chain', function () {
             it('fulfils the associativity property of chain #1', function (done) {
-                var f = function (x) { return Promise.of('f(' + x + ')'); },
-                    g = function (x) { return Promise.of('g(' + x + ')'); };
+                var f = function (x) { return fulfilledPromise('f(' + x + ')'); },
+                    g = function (x) { return fulfilledPromise('g(' + x + ')'); };
 
-                Promise.of('foo').chain(f).chain(g).map(function (x) {
+                fulfilledPromise('foo').chain(f).chain(g).map(function (x) {
                     assert.equal('g(f(foo))', x);
                     done();
                 });
             });
 
             it('fulfils the associativity property of chain #2', function (done) {
-                var f = function (x) { return Promise.of('f(' + x + ')'); },
-                    g = function (x) { return Promise.of('g(' + x + ')'); };
+                var f = function (x) { return fulfilledPromise('f(' + x + ')'); },
+                    g = function (x) { return fulfilledPromise('g(' + x + ')'); };
 
-                Promise.of('foo').chain(function (x) { return f(x).chain(g); }).map(function (x) {
+                fulfilledPromise('foo').chain(function (x) { return f(x).chain(g); }).map(function (x) {
                     assert.equal('g(f(foo))', x);
                     done();
                 });
@@ -537,20 +540,20 @@
 
         describe('#chainError', function () {
             it('fulfils the associativity property of chain #1', function (done) {
-                var f = function (x) { var p = new Promise(); p.reject('f(' + x + ')'); return p; },
-                    g = function (x) { var p = new Promise(); p.reject('g(' + x + ')'); return p; };
+                var f = function (x) { return rejectedPromise('f(' + x + ')'); },
+                    g = function (x) { return rejectedPromise('g(' + x + ')'); };
 
-                rejected('foo').chainError(f).chainError(g).mapError(function (x) {
+                rejectedPromise('foo').chainError(f).chainError(g).mapError(function (x) {
                     assert.equal('g(f(foo))', x);
                     done();
                 });
             });
 
             it('fulfils the associativity property of chain #2', function (done) {
-                var f = function (x) { var p = new Promise(); p.reject('f(' + x + ')'); return p; },
-                    g = function (x) { var p = new Promise(); p.reject('g(' + x + ')'); return p; };
+                var f = function (x) { return rejectedPromise('f(' + x + ')'); },
+                    g = function (x) { return rejectedPromise('g(' + x + ')'); };
 
-                rejected('foo').chainError(function (x) { return f(x).chainError(g); }).mapError(function (x) {
+                rejectedPromise('foo').chainError(function (x) { return f(x).chainError(g); }).mapError(function (x) {
                     assert.equal('g(f(foo))', x);
                     done();
                 });
@@ -559,18 +562,18 @@
 
         describe('#ap', function () {
             it('fulfils the identity property of applicative', function (done) {
-                Promise.of(function (a) { return a; }).ap(Promise.of('foo')).map(function (x) {
+                fulfilledPromise(function (a) { return a; }).ap(fulfilledPromise('foo')).map(function (x) {
                     assert.equal('foo', x);
                     done();
                 });
             });
 
             it('fulfils the composition property of applicative #1', function (done) {
-                var u = Promise.of(function (x) { return 'u(' + x + ')'; }),
-                    v = Promise.of(function (x) { return 'v(' + x + ')'; }),
-                    w = Promise.of('foo');
+                var u = fulfilledPromise(function (x) { return 'u(' + x + ')'; }),
+                    v = fulfilledPromise(function (x) { return 'v(' + x + ')'; }),
+                    w = fulfilledPromise('foo');
 
-                Promise.of(function (f) {
+                fulfilledPromise(function (f) {
                     return function (g) {
                         return function (x) {
                             return f(g(x));
@@ -583,9 +586,9 @@
             });
 
             it('fulfils the composition property of applicative #2', function (done) {
-                var u = Promise.of(function (x) { return 'u(' + x + ')'; }),
-                    v = Promise.of(function (x) { return 'v(' + x + ')'; }),
-                    w = Promise.of('foo');
+                var u = fulfilledPromise(function (x) { return 'u(' + x + ')'; }),
+                    v = fulfilledPromise(function (x) { return 'v(' + x + ')'; }),
+                    w = fulfilledPromise('foo');
 
                 u.ap(v.ap(w)).map(function (x) {
                     assert.equal('u(v(foo))', x);
@@ -596,7 +599,7 @@
             it('fulfils the homomorphism property of applicative #1', function (done) {
                 var f = function (x) { return 'f(' + x + ')'; };
 
-                Promise.of(f).ap(Promise.of('foo')).map(function (x) {
+                fulfilledPromise(f).ap(fulfilledPromise('foo')).map(function (x) {
                     assert.equal('f(foo)', x);
                     done();
                 });
@@ -605,27 +608,27 @@
             it('fulfils the homomorphism property of applicative #2', function (done) {
                 var f = function (x) { return 'f(' + x + ')'; };
 
-                Promise.of(f('foo')).map(function (x) {
+                fulfilledPromise(f('foo')).map(function (x) {
                     assert.equal('f(foo)', x);
                     done();
                 });
             });
 
             it('fulfils the interchange property of applicative #1', function (done) {
-                var u = Promise.of(function (x) { return 'u(' + x + ')'; }),
+                var u = fulfilledPromise(function (x) { return 'u(' + x + ')'; }),
                     y = 'y';
 
-                u.ap(Promise.of(y)).map(function (x) {
+                u.ap(fulfilledPromise(y)).map(function (x) {
                     assert.equal('u(y)', x);
                     done();
                 });
             });
 
             it('fulfils the interchange property of applicative #2', function (done) {
-                var u = Promise.of(function (x) { return 'u(' + x + ')'; }),
+                var u = fulfilledPromise(function (x) { return 'u(' + x + ')'; }),
                     y = 'y';
 
-                Promise.of(function (f) {
+                fulfilledPromise(function (f) {
                     return f(y);
                 }).ap(u).map(function (x) {
                     assert.equal('u(y)', x);
@@ -636,7 +639,7 @@
 
         describe('#empty', function () {
             it('conforms to the right identity', function (done) {
-                var p = Promise.of([1]);
+                var p = fulfilledPromise([1]);
 
                 p.concat(p.empty()).map(function (x) {
                     assert.deepEqual([1], x);
@@ -645,7 +648,7 @@
             });
 
             it('conforms to the left identity', function (done) {
-                var p = Promise.of([1]);
+                var p = fulfilledPromise([1]);
 
                 p.empty().concat(p).map(function (x) {
                     assert.deepEqual([1], x);
@@ -656,27 +659,32 @@
 
         describe('#conjoin', function () {
             it('concatenates values into a list regardless of type', function (done) {
-                Promise.of('foo').conjoin(Promise.of('bar')).conjoin(Promise.of('baz')).map(function (x) {
+                var p1 = fulfilledPromise('foo'),
+                    p2 = fulfilledPromise('bar'),
+                    p3 = fulfilledPromise('baz');
+
+                p1.conjoin(p2).conjoin(p3).map(function (x) {
                     assert.deepEqual(['foo', 'bar', 'baz'], x);
                     done();
                 });
             });
 
             it('concatenates values into a list even if already a list', function (done) {
-                var p = Promise.of([1]);
-                var p2 = Promise.of([2, 3]);
-                var p3 = Promise.of([4]);
+                var p1 = fulfilledPromise([1]),
+                    p2 = fulfilledPromise([2, 3]),
+                    p3 = fulfilledPromise([4]);
 
-                p.conjoin(p2).conjoin(p3).map(function (x) {
+                p1.conjoin(p2).conjoin(p3).map(function (x) {
                     assert.deepEqual([1, 2, 3, 4], x);
                     done();
                 });
             });
 
             it('concatenates values of mixed types', function (done) {
-                var p2 = Promise.of([2, 3]);
+                var p1 = fulfilledPromise('foo'),
+                    p2 = fulfilledPromise([2, 3]);
 
-                Promise.of('foo').conjoin(p2).map(function (x) {
+                p1.conjoin(p2).map(function (x) {
                     assert.deepEqual(['foo', 2, 3], x);
                     done();
                 });
@@ -685,32 +693,32 @@
 
         describe('#append', function () {
             it('appends promises to a promise of an array', function (done) {
-                var p = Promise.of([1]);
-                var p2 = Promise.of(2);
+                var p1 = fulfilledPromise([1]),
+                    p2 = fulfilledPromise(2);
 
-                p.append(p2).map(function (x) {
+                p1.append(p2).map(function (x) {
                     assert.deepEqual([1, 2], x);
                     done();
                 });
             });
 
             it('appends promises of arrays to arrays without joining them', function (done) {
-                var p = Promise.of([1]);
-                var p2 = Promise.of([2]);
+                var p1 = fulfilledPromise([1]),
+                    p2 = fulfilledPromise([2]);
 
-                p.append(p2).map(function (x) {
+                p1.append(p2).map(function (x) {
                     assert.deepEqual([1, [2]], x);
                     done();
                 });
             });
 
             it('can be chained without nesting arrays', function (done) {
-                var p = Promise.of([]);
-                var p2 = Promise.of([1]);
-                var p3 = Promise.of([2, 3]);
-                var p4 = Promise.of([4]);
+                var p1 = fulfilledPromise([]),
+                    p2 = fulfilledPromise([1]),
+                    p3 = fulfilledPromise([2, 3]),
+                    p4 = fulfilledPromise([4]);
 
-                p.append(p2).append(p3).append(p4).map(function (x) {
+                p1.append(p2).append(p3).append(p4).map(function (x) {
                     assert.deepEqual([[1], [2, 3], [4]], x);
                     done();
                 });
@@ -719,9 +727,7 @@
 
         describe('#spread', function () {
             it('calls the given function with each value of the Promise', function (done) {
-                var p = Promise.of([1, 2, 3]);
-
-                p.spread(function (x, y, z) {
+                fulfilledPromise([1, 2, 3]).spread(function (x, y, z) {
                     assert.equal(1, x);
                     assert.equal(2, y);
                     assert.equal(3, z);
@@ -730,9 +736,7 @@
             });
 
             it('returns a promise with a single value', function (done) {
-                var p = Promise.of([1, 2, 3]);
-
-                p.spread(function (x, y, z) {
+                fulfilledPromise([1, 2, 3]).spread(function (x, y, z) {
                     return x + y + z;
                 }).map(function (x) {
                     assert.equal(6, x);
@@ -743,9 +747,7 @@
 
         describe('#reduce', function () {
             it('returns a new promise with the result', function (done) {
-                var p = Promise.of([[1], [2], [3]]);
-
-                p.reduce(function (acc, e) {
+                fulfilledPromise([[1], [2], [3]]).reduce(function (acc, e) {
                     return acc.concat(e);
                 }).map(function (x) {
                     assert.deepEqual([1, 2, 3], x);
@@ -754,9 +756,7 @@
             });
 
             it('takes an optional initial value', function (done) {
-                var p = Promise.of([1, 2, 3]);
-
-                p.reduce(function (acc, e) {
+                fulfilledPromise([1, 2, 3]).reduce(function (acc, e) {
                     return acc + e;
                 }, 0).map(function (x) {
                     assert.equal(6, x);


### PR DESCRIPTION
As @benschulz saw intermittent test failures when working on https://github.com/mudge/pacta/pull/7, stop using a `beforeEach` to set up promises and be explicit within each test case about its data. To aid with this task, use simple builder methods (e.g. `rejectedPromise`, `fulfilledPromise`) rather than coupling directly to the Promise constructor.