### PR TITLE
Encapsulate exceptions during chain and chainError

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,8 +532,10 @@ list to the function separately.
 
 ## Contributors
 
-`mapError` and `chainError` were contributed by [Rodolphe
-Belouin](https://github.com/rbelouin).
+* Fixes to `chain`, `chainError` and `empty` were contributed by [Ben
+  Schulz](https://github.com/benschulz);
+* `mapError` and `chainError` were contributed by [Rodolphe
+  Belouin](https://github.com/rbelouin).
 
 ## Acknowledgements
 

--- a/lib/pacta.js
+++ b/lib/pacta.js
@@ -361,7 +361,9 @@
 
     /* empty :: Promise e a -> Promise e a */
     Promise.prototype.empty = function () {
-        return Promise.of(this.value.empty ? this.value.empty() : this.value.constructor.empty());
+        return this.map(function (value) {
+            return value.empty ? value.empty() : value.constructor.empty();
+        });
     };
 
     /* conjoin :: Promise e a   -> Promise e b   -> Promise e [a b]

--- a/lib/pacta.js
+++ b/lib/pacta.js
@@ -276,20 +276,25 @@
     Promise.prototype.chain = function (f) {
         var promise = new Promise();
 
-        /* Map over the given Promise a with (a -> Promise b), returning a new
-         * Promise (Promise b). Map over that, thereby gaining access to the inner
+        /* Map over the given Promise a calling (a -> Promise b) to return a new
          * Promise b. Map over that in order to get to the inner value of b and
          * resolve another promise with it. Return that promise as it is equivalent
          * to Promise b.
          */
-        this.map(f).map(function (pb) {
-            pb.map(function (value) {
-                promise.resolve(value);
-            });
+        this.map(function (value) {
+            try {
+                var pb = f(value);
 
-            pb.onRejected(function (reason) {
-                promise.reject(reason);
-            });
+                pb.map(function (value) {
+                    promise.resolve(value);
+                });
+
+                pb.onRejected(function (reason) {
+                    promise.reject(reason);
+                });
+            } catch (e) {
+                promise.reject(e);
+            }
         });
 
         this.onRejected(function (reason) {
@@ -303,18 +308,23 @@
     Promise.prototype.chainError = function (f) {
         var promise = new Promise();
 
-        /* Same algorithm as above */
-        this.mapError(f).mapError(function (pb) {
-            pb.map(function (value) {
-                promise.resolve(value);
-            });
+        this.mapError(function (reason) {
+            try {
+                var pb = f(reason);
 
-            pb.onRejected(function (reason) {
-                promise.reject(reason);
-            });
+                pb.map(function (value) {
+                    promise.resolve(value);
+                });
+
+                pb.onRejected(function (reason) {
+                    promise.reject(reason);
+                });
+            } catch (e) {
+                promise.reject(e);
+            }
         });
 
-        this.map(function(value) {
+        this.map(function (value) {
             promise.resolve(value);
         });
 

--- a/test/pacta_test.js
+++ b/test/pacta_test.js
@@ -697,6 +697,17 @@
                     done();
                 });
             });
+
+            it('works with unresolved promises', function (done) {
+                var p = emptyPromise();
+
+                p.concat(p.empty()).map(function (x) {
+                    assert.deepEqual([1], x);
+                    done();
+                });
+
+                p.resolve([1]);
+            });
         });
 
         describe('#conjoin', function () {

--- a/test/pacta_test.js
+++ b/test/pacta_test.js
@@ -536,6 +536,27 @@
                     done();
                 });
             });
+
+            it('encapsulates exceptions in rejections', function (done) {
+                var exception = new TypeError(),
+                    p = fulfilledPromise().chain(function () { throw exception; });
+
+                p.onRejected(function (r) {
+                    assert.equal('rejected', p.state());
+                    assert.equal(exception, r);
+                    done();
+                });
+            });
+
+            it('rejects the returned promise, if f does not return a promise', function (done) {
+                var p = fulfilledPromise().chain(function () { return 'not-a-promise'; });
+
+                p.onRejected(function (r) {
+                    assert.equal('rejected', p.state());
+                    assert.equal(TypeError, r.constructor);
+                    done();
+                });
+            });
         });
 
         describe('#chainError', function () {
@@ -555,6 +576,27 @@
 
                 rejectedPromise('foo').chainError(function (x) { return f(x).chainError(g); }).mapError(function (x) {
                     assert.equal('g(f(foo))', x);
+                    done();
+                });
+            });
+
+            it('encapsulates exceptions in rejections', function (done) {
+                var exception = new TypeError(),
+                    p = rejectedPromise().chainError(function () { throw exception; });
+
+                p.onRejected(function (r) {
+                    assert.equal('rejected', p.state());
+                    assert.equal(exception, r);
+                    done();
+                });
+            });
+
+            it('rejects the returned promise, if f does not return a promise', function (done) {
+                var p = rejectedPromise().chainError(function () { return 'not-a-promise'; });
+
+                p.onRejected(function (r) {
+                    assert.equal('rejected', p.state());
+                    assert.equal(TypeError, r.constructor);
                     done();
                 });
             });


### PR DESCRIPTION
If the function passed to `chain` or `chainError` returned a non-promise type (specifically, a type that does not implement `map` or `onRejected`) then an exception would be thrown. This would typically happen if an exception was thrown during the passed function. Now use any exception thrown during a `chain` or `chainError` to reject the resulting promise.

@benschulz this is taken from your branch, rebased against master and edited to provide symmetry between `chain` and `chainError`. Are you happy with this?